### PR TITLE
feat: add selector-based subscribe to Store

### DIFF
--- a/Sources/Store/SelectorSubscription.swift
+++ b/Sources/Store/SelectorSubscription.swift
@@ -1,0 +1,19 @@
+/// A handle for a selector-based subscription that can be cancelled
+///
+/// When a subscription is created via `Store.subscribe(selector:listener:)`,
+/// a `Subscription` instance is returned. Call `cancel()` to stop receiving
+/// notifications when the selected value changes.
+@MainActor
+public final class Subscription {
+  private var onCancel: (() -> Void)?
+
+  init(onCancel: @escaping () -> Void) {
+    self.onCancel = onCancel
+  }
+
+  /// Cancels the subscription, stopping further listener invocations
+  public func cancel() {
+    onCancel?()
+    onCancel = nil
+  }
+}

--- a/Sources/Store/Store.swift
+++ b/Sources/Store/Store.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Observation
 
 /// A Zustand-like state management store for SwiftUI
@@ -18,6 +19,9 @@ public final class Store<State: Sendable> {
   /// - Note: State changes automatically trigger SwiftUI view updates via @Observable
   public private(set) var state: State
 
+  /// Registered selector-based subscriptions, keyed by unique ID
+  private var subscriptions: [UUID: (State, State) -> Void] = [:]
+
   /// Initializes the store with an initial state
   ///
   /// - Parameter initialState: The initial state value for the store
@@ -28,13 +32,67 @@ public final class Store<State: Sendable> {
   /// Updates the store's state using a functional setter
   ///
   /// This method creates a copy of the current state, applies the updater function
-  /// to modify it, and then sets the new state.
+  /// to modify it, and then sets the new state. After updating, all registered
+  /// selector subscriptions are notified.
   ///
   /// - Parameter updater: A closure that receives an inout reference to the state for modification
   func set(_ updater: StateUpdater<State>) {
+    let oldState = state
     var newState = state
     updater(&newState)
     self.state = newState
+    notifySubscriptions(oldState: oldState, newState: newState)
+  }
+
+  /// Subscribes to changes of a selected value using `Equatable` conformance for comparison
+  ///
+  /// The listener is called only when the selected value changes according to `Equatable`.
+  /// Returns a `Subscription` handle that can be used to cancel the subscription.
+  ///
+  /// - Parameters:
+  ///   - selector: A closure that extracts the value of interest from the state
+  ///   - listener: A closure called with the old and new selected values when a change is detected
+  /// - Returns: A ``Subscription`` that can be cancelled to stop receiving notifications
+  public func subscribe<Selected: Equatable>(
+    selector: @escaping (State) -> Selected,
+    listener: @escaping @MainActor @Sendable (Selected, Selected) -> Void
+  ) -> Subscription {
+    subscribe(selector: selector, equalityFn: { $0 == $1 }, listener: listener)
+  }
+
+  /// Subscribes to changes of a selected value using a custom equality function for comparison
+  ///
+  /// The listener is called only when the selected value changes according to the provided
+  /// equality function. Returns a `Subscription` handle that can be used to cancel the subscription.
+  ///
+  /// - Parameters:
+  ///   - selector: A closure that extracts the value of interest from the state
+  ///   - equalityFn: A closure that determines whether two selected values are equal
+  ///   - listener: A closure called with the old and new selected values when a change is detected
+  /// - Returns: A ``Subscription`` that can be cancelled to stop receiving notifications
+  public func subscribe<Selected>(
+    selector: @escaping (State) -> Selected,
+    equalityFn: @escaping @Sendable (Selected, Selected) -> Bool,
+    listener: @escaping @MainActor @Sendable (Selected, Selected) -> Void
+  ) -> Subscription {
+    let id = UUID()
+
+    subscriptions[id] = { oldState, newState in
+      let oldSelected = selector(oldState)
+      let newSelected = selector(newState)
+      guard !equalityFn(oldSelected, newSelected) else { return }
+      listener(oldSelected, newSelected)
+    }
+
+    return Subscription {
+      self.subscriptions.removeValue(forKey: id)
+    }
+  }
+
+  private func notifySubscriptions(oldState: State, newState: State) {
+    for handler in subscriptions.values {
+      handler(oldState, newState)
+    }
   }
 }
 

--- a/Tests/StoreTests/SelectorSubscriptionTests.swift
+++ b/Tests/StoreTests/SelectorSubscriptionTests.swift
@@ -1,0 +1,145 @@
+import Testing
+
+@testable import Store
+
+@Suite
+struct SelectorSubscriptionTests {
+  struct State: Sendable {
+    var count: Int = 0
+    var name: String = "initial"
+  }
+
+  struct Action {
+    let increment: () -> Void
+    let setName: (String) -> Void
+  }
+
+  @MainActor
+  func useStore() -> (store: Store<State>, action: Action) {
+    createStore(initialState: State()) { set in
+      Action(
+        increment: {
+          set { $0.count += 1 }
+        },
+        setName: { name in
+          set { $0.name = name }
+        }
+      )
+    }
+  }
+
+  @MainActor
+  @Test
+  func subscribeWithEquatableSelector_firesOnChange() {
+    let (store, action) = useStore()
+
+    var receivedValues: [(old: Int, new: Int)] = []
+    let subscription = store.subscribe(selector: { $0.count }) { oldValue, newValue in
+      receivedValues.append((old: oldValue, new: newValue))
+    }
+
+    action.increment()
+    #expect(receivedValues.count == 1)
+    #expect(receivedValues[0].old == 0)
+    #expect(receivedValues[0].new == 1)
+
+    action.increment()
+    #expect(receivedValues.count == 2)
+    #expect(receivedValues[1].old == 1)
+    #expect(receivedValues[1].new == 2)
+
+    subscription.cancel()
+  }
+
+  @MainActor
+  @Test
+  func subscribeWithEquatableSelector_doesNotFireWhenUnchanged() {
+    let (store, action) = useStore()
+
+    var fireCount = 0
+    let subscription = store.subscribe(selector: { $0.count }) { _, _ in
+      fireCount += 1
+    }
+
+    // Changing name should not fire the count selector listener
+    action.setName("updated")
+    #expect(fireCount == 0)
+
+    // Changing count should fire
+    action.increment()
+    #expect(fireCount == 1)
+
+    subscription.cancel()
+  }
+
+  @MainActor
+  @Test
+  func subscribeWithCustomEqualityFn() {
+    let (store, action) = useStore()
+
+    var receivedValues: [(old: Int, new: Int)] = []
+    // Custom equality: treat values as equal if both are even or both are odd
+    let subscription = store.subscribe(
+      selector: { $0.count },
+      equalityFn: { $0 % 2 == $1 % 2 }
+    ) { oldValue, newValue in
+      receivedValues.append((old: oldValue, new: newValue))
+    }
+
+    // 0 -> 1: different parity, should fire
+    action.increment()
+    #expect(receivedValues.count == 1)
+
+    // 1 -> 2: different parity, should fire
+    action.increment()
+    #expect(receivedValues.count == 2)
+
+    subscription.cancel()
+  }
+
+  @MainActor
+  @Test
+  func subscriptionCancel_stopsNotifications() {
+    let (store, action) = useStore()
+
+    var fireCount = 0
+    let subscription = store.subscribe(selector: { $0.count }) { _, _ in
+      fireCount += 1
+    }
+
+    action.increment()
+    #expect(fireCount == 1)
+
+    subscription.cancel()
+
+    action.increment()
+    #expect(fireCount == 1)
+  }
+
+  @MainActor
+  @Test
+  func multipleSubscriptions_workIndependently() {
+    let (store, action) = useStore()
+
+    var countFires = 0
+    var nameFires = 0
+
+    let sub1 = store.subscribe(selector: { $0.count }) { _, _ in
+      countFires += 1
+    }
+    let sub2 = store.subscribe(selector: { $0.name }) { _, _ in
+      nameFires += 1
+    }
+
+    action.increment()
+    #expect(countFires == 1)
+    #expect(nameFires == 0)
+
+    action.setName("hello")
+    #expect(countFires == 1)
+    #expect(nameFires == 1)
+
+    sub1.cancel()
+    sub2.cancel()
+  }
+}


### PR DESCRIPTION
## Summary
- Add `Subscription` type (`SelectorSubscription.swift`) as a cancellable handle for selector-based subscriptions
- Add `subscribe(selector:listener:)` for `Equatable` selected values and `subscribe(selector:equalityFn:listener:)` for custom comparison
- Integrate subscription notification into `Store.set(_:)` so listeners fire only when the selected value changes
- Add 5 tests covering: fire on change, skip when unchanged, custom equality, cancellation, and independent multiple subscriptions

## Test plan
- [x] All 8 existing + new tests pass via `swift test`
- [x] Equatable selector fires only when selected value changes
- [x] Custom equality function controls when listener fires
- [x] Cancelling a subscription stops notifications
- [x] Multiple subscriptions on different selectors work independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)