### PR TITLE
feat: add PersistMiddleware for state persistence

### DIFF
--- a/Sources/Store/Middleware/PersistMiddleware.swift
+++ b/Sources/Store/Middleware/PersistMiddleware.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Middleware that automatically persists state changes to storage
+///
+/// After each state update, ``PersistMiddleware`` encodes the new state as JSON
+/// and saves it to the provided ``PersistStorage``. Use ``loadState(key:storage:fallback:)``
+/// to restore persisted state at initialization time.
+///
+/// ## Usage Example
+/// ```swift
+/// let storage = UserDefaultsStorage()
+/// let initialState = PersistMiddleware<AppState>.loadState(
+///   key: "app",
+///   storage: storage,
+///   fallback: AppState()
+/// )
+/// let (store, actions) = createStore(
+///   initialState: initialState,
+///   middleware: [PersistMiddleware<AppState>(key: "app", storage: storage)]
+/// ) { set in
+///   AppActions(...)
+/// }
+/// ```
+public struct PersistMiddleware<State: Codable & Sendable>: Middleware {
+  private let key: String
+  private let storage: any PersistStorage
+
+  /// Creates a persist middleware
+  ///
+  /// - Parameters:
+  ///   - key: The storage key used to persist and restore state
+  ///   - storage: The storage backend (defaults to ``UserDefaultsStorage``)
+  public init(key: String, storage: any PersistStorage = UserDefaultsStorage()) {
+    self.key = key
+    self.storage = storage
+  }
+
+  public func apply(currentState: State, next: StateSet<State>) -> StateSet<State> {
+    let key = self.key
+    let storage = self.storage
+
+    return StateSet<State> { updater in
+      var newState = currentState
+      updater(&newState)
+
+      if let data = try? JSONEncoder().encode(newState) {
+        storage.save(key: key, data: data)
+      }
+
+      next { state in
+        state = newState
+      }
+    }
+  }
+
+  /// Restore persisted state from storage
+  ///
+  /// Use this method to hydrate the initial state when creating a store.
+  /// If no data is found or decoding fails, the fallback value is returned.
+  ///
+  /// - Parameters:
+  ///   - key: The storage key to load from
+  ///   - storage: The storage backend
+  ///   - fallback: The default state to use when no persisted data is available
+  /// - Returns: The restored state, or the fallback if restoration fails
+  public static func loadState(
+    key: String,
+    storage: any PersistStorage,
+    fallback: State
+  ) -> State {
+    guard let data = storage.load(key: key) else {
+      return fallback
+    }
+    return (try? JSONDecoder().decode(State.self, from: data)) ?? fallback
+  }
+}

--- a/Sources/Store/Middleware/PersistStorage.swift
+++ b/Sources/Store/Middleware/PersistStorage.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Protocol for key-value data persistence
+///
+/// Conform to this protocol to provide a custom storage backend
+/// for ``PersistMiddleware``. The library ships with ``UserDefaultsStorage``
+/// as a default implementation.
+public protocol PersistStorage: Sendable {
+  /// Load data for the given key
+  ///
+  /// - Parameter key: The storage key
+  /// - Returns: The stored data, or `nil` if no data exists
+  func load(key: String) -> Data?
+
+  /// Save data for the given key
+  ///
+  /// - Parameters:
+  ///   - key: The storage key
+  ///   - data: The data to persist
+  func save(key: String, data: Data)
+
+  /// Remove data for the given key
+  ///
+  /// - Parameter key: The storage key
+  func remove(key: String)
+}
+
+/// A ``PersistStorage`` implementation backed by `UserDefaults`
+///
+/// `UserDefaults` is thread-safe, so this type opts into `Sendable`
+/// via `@unchecked Sendable`.
+public final class UserDefaultsStorage: PersistStorage, @unchecked Sendable {
+  private let defaults: UserDefaults
+
+  /// Creates a storage backed by the given `UserDefaults` instance
+  ///
+  /// - Parameter defaults: The `UserDefaults` instance to use (defaults to `.standard`)
+  public init(defaults: UserDefaults = .standard) {
+    self.defaults = defaults
+  }
+
+  public func load(key: String) -> Data? {
+    defaults.data(forKey: key)
+  }
+
+  public func save(key: String, data: Data) {
+    defaults.set(data, forKey: key)
+  }
+
+  public func remove(key: String) {
+    defaults.removeObject(forKey: key)
+  }
+}

--- a/Tests/StoreTests/PersistMiddlewareTests.swift
+++ b/Tests/StoreTests/PersistMiddlewareTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+
+@testable import Store
+
+@Suite
+struct PersistMiddlewareTests {
+  struct TestState: Codable, Sendable, Equatable {
+    var count: Int = 0
+    var name: String = ""
+  }
+
+  /// In-memory storage for testing
+  final class InMemoryStorage: PersistStorage, @unchecked Sendable {
+    var data: [String: Data] = [:]
+
+    func load(key: String) -> Data? {
+      data[key]
+    }
+
+    func save(key: String, data: Data) {
+      self.data[key] = data
+    }
+
+    func remove(key: String) {
+      data.removeValue(forKey: key)
+    }
+  }
+
+  @MainActor
+  @Test
+  func savesStateAfterUpdate() {
+    let storage = InMemoryStorage()
+    let middleware = PersistMiddleware<TestState>(key: "test", storage: storage)
+    let initialState = TestState(count: 0, name: "")
+
+    var finalState = initialState
+    let stateSet = middleware.apply(
+      currentState: initialState,
+      next: StateSet<TestState> { updater in
+        var state = initialState
+        updater(&state)
+        finalState = state
+      }
+    )
+
+    stateSet { state in
+      state.count = 42
+      state.name = "hello"
+    }
+
+    #expect(finalState.count == 42)
+    #expect(finalState.name == "hello")
+
+    // Verify data was persisted
+    let savedData = storage.load(key: "test")
+    #expect(savedData != nil)
+
+    let decoded = try! JSONDecoder().decode(TestState.self, from: savedData!)
+    #expect(decoded.count == 42)
+    #expect(decoded.name == "hello")
+  }
+
+  @MainActor
+  @Test
+  func loadStateRestoresFromStorage() {
+    let storage = InMemoryStorage()
+    let state = TestState(count: 99, name: "persisted")
+    let data = try! JSONEncoder().encode(state)
+    storage.save(key: "test", data: data)
+
+    let loaded = PersistMiddleware<TestState>.loadState(
+      key: "test",
+      storage: storage,
+      fallback: TestState()
+    )
+
+    #expect(loaded.count == 99)
+    #expect(loaded.name == "persisted")
+  }
+
+  @MainActor
+  @Test
+  func loadStateReturnsFallbackWhenNoData() {
+    let storage = InMemoryStorage()
+    let fallback = TestState(count: 0, name: "default")
+
+    let loaded = PersistMiddleware<TestState>.loadState(
+      key: "missing",
+      storage: storage,
+      fallback: fallback
+    )
+
+    #expect(loaded == fallback)
+  }
+
+  @MainActor
+  @Test
+  func loadStateReturnsFallbackWhenDataIsCorrupted() {
+    let storage = InMemoryStorage()
+    storage.save(key: "test", data: Data("invalid json".utf8))
+
+    let fallback = TestState(count: 0, name: "default")
+    let loaded = PersistMiddleware<TestState>.loadState(
+      key: "test",
+      storage: storage,
+      fallback: fallback
+    )
+
+    #expect(loaded == fallback)
+  }
+
+  @MainActor
+  @Test
+  func worksWithCreateStore() {
+    let storage = InMemoryStorage()
+
+    struct Actions {
+      let setCount: (Int) -> Void
+    }
+
+    let middleware = PersistMiddleware<TestState>(key: "store-test", storage: storage)
+    let (store, actions) = createStore(
+      initialState: TestState(),
+      middleware: [middleware]
+    ) { set in
+      Actions(
+        setCount: { value in set { $0.count = value } }
+      )
+    }
+
+    actions.setCount(10)
+    #expect(store.state.count == 10)
+
+    // Verify persisted
+    let savedData = storage.load(key: "store-test")
+    #expect(savedData != nil)
+    let decoded = try! JSONDecoder().decode(TestState.self, from: savedData!)
+    #expect(decoded.count == 10)
+  }
+}


### PR DESCRIPTION
## Summary
- Add `PersistStorage` protocol with `load`/`save`/`remove` methods and `UserDefaultsStorage` default implementation
- Add `PersistMiddleware` that auto-persists state as JSON after each update, with `loadState` static method for hydration at startup
- Add 5 tests covering save-on-update, load/hydration, fallback on missing/corrupted data, and integration with `createStore`

## Test plan
- [x] `swift test` passes with all 8 tests (5 new + 3 existing)
- [x] Tests use in-memory `PersistStorage` implementation (no UserDefaults side effects)
- [x] Verified corrupted data gracefully falls back to default state

🤖 Generated with [Claude Code](https://claude.com/claude-code)