### PR TITLE
feat: add subscribe API and destroy method

### DIFF
--- a/Sources/Store/Store.swift
+++ b/Sources/Store/Store.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Observation
 
 /// A Zustand-like state management store for SwiftUI
@@ -18,6 +19,8 @@ public final class Store<State: Sendable> {
   /// - Note: State changes automatically trigger SwiftUI view updates via @Observable
   public private(set) var state: State
 
+  private var subscriptions: [UUID: @MainActor @Sendable (State, State) -> Void] = [:]
+
   /// Initializes the store with an initial state
   ///
   /// - Parameter initialState: The initial state value for the store
@@ -28,13 +31,43 @@ public final class Store<State: Sendable> {
   /// Updates the store's state using a functional setter
   ///
   /// This method creates a copy of the current state, applies the updater function
-  /// to modify it, and then sets the new state.
+  /// to modify it, and then sets the new state. All active subscribers are notified
+  /// with the new and previous state values.
   ///
   /// - Parameter updater: A closure that receives an inout reference to the state for modification
   func set(_ updater: StateUpdater<State>) {
+    let previousState = state
     var newState = state
     updater(&newState)
     self.state = newState
+
+    for listener in subscriptions.values {
+      listener(newState, previousState)
+    }
+  }
+
+  /// Subscribes a listener to state changes
+  ///
+  /// The listener is called each time the store's state is updated via `set(_:)`,
+  /// receiving both the new state and the previous state.
+  ///
+  /// - Parameter listener: A closure called on each state change with (newState, previousState)
+  /// - Returns: A `Subscription` that can be used to cancel the subscription
+  public func subscribe(
+    _ listener: @escaping @MainActor @Sendable (State, State) -> Void
+  ) -> Subscription {
+    let id = UUID()
+    subscriptions[id] = listener
+    return Subscription { [weak self] in
+      self?.subscriptions.removeValue(forKey: id)
+    }
+  }
+
+  /// Destroys all active subscriptions
+  ///
+  /// After calling this method, no listeners will receive further state change notifications.
+  public func destroy() {
+    subscriptions.removeAll()
   }
 }
 

--- a/Sources/Store/Subscription.swift
+++ b/Sources/Store/Subscription.swift
@@ -1,0 +1,19 @@
+/// A handle for managing a store subscription
+///
+/// When you subscribe to a store, a `Subscription` is returned that can be used
+/// to cancel the subscription when it is no longer needed.
+@MainActor
+public final class Subscription: Sendable {
+  private let onCancel: @MainActor @Sendable () -> Void
+
+  init(onCancel: @escaping @MainActor @Sendable () -> Void) {
+    self.onCancel = onCancel
+  }
+
+  /// Cancels this subscription
+  ///
+  /// After calling this method, the listener will no longer receive state change notifications.
+  public func cancel() {
+    onCancel()
+  }
+}

--- a/Tests/StoreTests/SubscriptionTests.swift
+++ b/Tests/StoreTests/SubscriptionTests.swift
@@ -1,0 +1,93 @@
+import Testing
+
+@testable import Store
+
+@Suite
+struct SubscriptionTests {
+  struct State: Sendable {
+    var count: Int = 0
+  }
+
+  struct Action {
+    let increment: () -> Void
+  }
+
+  @MainActor
+  func useStore() -> (store: Store<State>, action: Action) {
+    createStore(initialState: State()) { set in
+      Action(
+        increment: { set { $0.count += 1 } }
+      )
+    }
+  }
+
+  @MainActor
+  @Test
+  func subscribeReceivesStateChanges() {
+    let (store, action) = useStore()
+
+    var received: [(newState: State, previousState: State)] = []
+    _ = store.subscribe { newState, previousState in
+      received.append((newState, previousState))
+    }
+
+    action.increment()
+
+    #expect(received.count == 1)
+    #expect(received[0].newState.count == 1)
+    #expect(received[0].previousState.count == 0)
+  }
+
+  @MainActor
+  @Test
+  func subscriptionCancel() {
+    let (store, action) = useStore()
+
+    var callCount = 0
+    let subscription = store.subscribe { _, _ in
+      callCount += 1
+    }
+
+    action.increment()
+    #expect(callCount == 1)
+
+    subscription.cancel()
+
+    action.increment()
+    #expect(callCount == 1)
+  }
+
+  @MainActor
+  @Test
+  func multipleSubscriptions() {
+    let (store, action) = useStore()
+
+    var callCountA = 0
+    var callCountB = 0
+    _ = store.subscribe { _, _ in callCountA += 1 }
+    _ = store.subscribe { _, _ in callCountB += 1 }
+
+    action.increment()
+
+    #expect(callCountA == 1)
+    #expect(callCountB == 1)
+  }
+
+  @MainActor
+  @Test
+  func destroyClearsAllSubscriptions() {
+    let (store, action) = useStore()
+
+    var callCount = 0
+    _ = store.subscribe { _, _ in callCount += 1 }
+    _ = store.subscribe { _, _ in callCount += 1 }
+
+    action.increment()
+    #expect(callCount == 2)
+
+    store.destroy()
+
+    action.increment()
+    #expect(callCount == 2)
+  }
+}


### PR DESCRIPTION
## Summary
- `Store.subscribe(_:)` でリスナーベースの状態変更購読を追加（`(newState, previousState)` を通知）
- `Subscription` 型で `cancel()` による購読解除をサポート
- `Store.destroy()` で全購読を一括解除
- zustand の `subscribe` API に相当する機能

## Test plan
- [x] リスナーが状態変更時に正しい new/previous state を受け取ることを検証
- [x] `cancel()` 後にリスナーが呼ばれないことを検証
- [x] 複数購読の同時動作を検証
- [x] `destroy()` で全購読解除されることを検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)