### PR TITLE
fix: use octocov built-in predicates for if conditions

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -14,19 +14,19 @@ codeToTestRatio:
   badge:
     path: docs/ratio.svg
 testExecutionTime:
-  if: github.event_name == 'push'
+  if: true
   badge:
     path: docs/time.svg
 report:
-  if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  if: is_default_branch
   datastores:
     - artifact://${GITHUB_REPOSITORY}
 comment:
-  if: github.event_name == 'pull_request'
+  if: is_pull_request
 diff:
   datastores:
     - artifact://${GITHUB_REPOSITORY}
 summary:
   if: true
 push:
-  if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  if: is_default_branch


### PR DESCRIPTION
## Summary

After #26, the octocov CI run on `main` still skipped both report storage and file push:

```
Skip storing report: the condition in the `if` section is not met (github.event_name == 'push' && github.ref == 'refs/heads/main')
Skip pushing generate files: the condition in the `if` section is not met (github.event_name == 'push' && github.ref == 'refs/heads/main')
```

octocov's expression engine does not expose the full GitHub Actions `github.*` context the way the condition assumed, so `github.ref == 'refs/heads/main'` silently evaluates to false on the default branch. As a result `docs/coverage.svg`, `docs/ratio.svg`, and `docs/time.svg` were never committed.

Switch to octocov's built-in predicates (same style as [k1LoW/mo](https://github.com/k1LoW/mo/blob/main/.octocov.yml)):

- `is_default_branch` for `report.if` and `push.if`
- `is_pull_request` for `comment.if`
- `true` for `testExecutionTime.if` (always capture; it was pushed-only before, which dropped the value on PR runs)

## Test plan

- [ ] After merging to `main`, the CI log shows `Storing report` / `Pushing generate files` instead of the Skip messages.
- [ ] `docs/coverage.svg`, `docs/ratio.svg`, `docs/time.svg` are committed to `main` by octocov.
- [ ] All three README badges render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)